### PR TITLE
Actually Disable strict hostkey checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ supervisor rsync samba-client iputils openssh openssl rrdtool msmtp lighttpd lig
 
 # Disable strict host key checking
 && sed -i -e 's/^# Host \*/Host */g' /etc/ssh/ssh_config \
-&& sed -i -e 's/^#   StrictHostKeyChecking ask/    StrictHostKeyChecking yes/g' /etc/ssh/ssh_config \
+&& sed -i -e 's/^#   StrictHostKeyChecking ask/    StrictHostKeyChecking no/g' /etc/ssh/ssh_config \
 
 # Get BackupPC, it will be installed at runtime to allow dynamic upgrade of existing config/pool
 && curl -o /root/BackupPC-$BACKUPPC_VERSION.tar.gz -L https://github.com/backuppc/backuppc/releases/download/$BACKUPPC_VERSION/BackupPC-$BACKUPPC_VERSION.tar.gz \


### PR DESCRIPTION
The comment above this specifically mentions it's supposed to be disabling strict hostkey checking, but it's actually just enforcing it without prompting the user. Obviously we don't want to prompt the user since the user is backuppc itself running inside the container. But this looks like it means the backuppc user will just reject any new servers it's trying to ssh to. 

I think the behavior you were going for (or at least the one that works for me) is to hard disable it.

If I've misunderstood, feel free to reject this pull request. 

Thank you for your time and attention.