### PR TITLE
TimeZone: fix inverted check of TZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ docker run \
     adferrand/backuppc
 ```
 
-Alternatively, you can sync the container timezone to its host by mounting the host file `/etc/localtime` to the container path `/etc/localtime`.
+Alternatively, depending on the host OS, you can sync the container timezone to its host by mounting the host file `/etc/localtime` to the container path `/etc/localtime`.
 
 ```bash
 docker run \

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -f /firstrun ]; then
 	echo 'If exist, configuration and data will be reused and upgraded as needed.'
 
 	# Configure timezone if needed
-	if [ -z "$TZ" ]; then
+	if [ -n "$TZ" ]; then
 		cp /usr/share/zoneinfo/$TZ /etc/localtime 
 	fi
 


### PR DESCRIPTION
Timezone with TZ didn't work, due to inverted check of the TZ setting.

Also, with Ubuntu 16.04.3 on the host, mounting /etc/localtime from host to container
does not work (the container exits with error in entrypoint.sh), so I
rephrased the README a little.