### PR TITLE
Use container's hostname instead of localhost as backuppc hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,18 @@ The configure.pl script will detect a v3.x version under /etc/backuppc, and will
 
 ## Miscellaneous
 
+### Hostname
+
+The backuppc host name will default to the container's hostname. You can modify this by setting `--hostname` in your `docker run` command like so:
+
+```bash
+docker run \
+    --name backuppc \
+    --hostname backuppc.example.org \
+    --publish 80:8080 \
+    adferrand/backuppc
+```
+
 ### Timezone
 
 By default the timezone of this docker is set to UTC. To modify it, you can specify a tzdata-compatible timezone in the environment variable `TZ`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 * [Upgrading](#upgrading)
 	* [Dockerising an existing BackupPC v3.x](#dockerising-an-existing-backuppc-v3x)
 * [Miscellaneous](#miscellaneous)
+    * [Hostname](#hostname)
     * [Timezone](#timezone)
     * [Shell access](#shell-access)
     * [Legacy version](#legacy-version)

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -59,7 +59,7 @@ if [ -f /firstrun ]; then
 		--cgi-dir /var/www/cgi-bin/BackupPC \
 		--data-dir /data/backuppc \
 		--log-dir /data/backuppc/log \
-		--hostname localhost \
+		--hostname $(</etc/hostname) \
 		--html-dir /var/www/html/BackupPC \
 		--html-dir-url /BackupPC \
 		--install-dir /usr/local/BackupPC \


### PR DESCRIPTION
Easily configurable by setting `--hostname` in `docker run`.