### PR TITLE
Fix firstrun flag

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -116,7 +116,7 @@ if [ -f /firstrun ]; then
 	chown "${BACKUPPC_USERNAME}:${BACKUPPC_GROUPNAME}" /var/log/msmtp.log
 
 	# Clean
-	rm -rf "/root/BackupPC-$BACKUPPC_VERSION.tar.gz" "/root/BackupPC-$BACKUPPC_VERSION /firstrun"
+	rm -rf "/root/BackupPC-$BACKUPPC_VERSION.tar.gz" "/root/BackupPC-$BACKUPPC_VERSION" /firstrun
 fi
 
 export BACKUPPC_UUID


### PR DESCRIPTION
Fixes #31

Credit to @tadr0 for spotting it[1]. Problem introduced when adding quotes here[2].

I tested this from my branch, and my container can now restart cleanly again:

```
2020-08-12 23:30:42,646 WARN received SIGTERM indicating exit request
2020-08-12 23:30:42,647 INFO waiting for backuppc, lighttpd, watchmails to die
2020-08-12 23:30:42,648 INFO stopped: watchmails (terminated by SIGTERM)
2020-08-12 23:30:42,650 INFO stopped: lighttpd (exit status 0)
2020-08-12 23:30:43,652 INFO stopped: backuppc (exit status 0)
2020-08-12 23:30:46,304 INFO Set uid to user 0 succeeded
2020-08-12 23:30:46,309 INFO RPC interface 'supervisor' initialized
2020-08-12 23:30:46,310 INFO supervisord started with pid 1
2020-08-12 23:30:47,314 INFO spawned: 'backuppc' with pid 13
2020-08-12 23:30:47,317 INFO spawned: 'lighttpd' with pid 14
2020-08-12 23:30:47,319 INFO spawned: 'watchmails' with pid 15
2020-08-12 23:30:48,426 INFO success: backuppc entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```

[1] https://github.com/adferrand/docker-backuppc/issues/31#issuecomment-672891314
[2] https://github.com/adferrand/docker-backuppc/commit/95034418c1a378dc6a437aa969865016240457c6#diff-46bd948566ee03504c6421cadd8047faR119