### PR TITLE
Add perl-time-parsedate to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV RSYNC_BPC_VERSION="${RSYNC_BPC_VERSION}"
 RUN apk --no-cache --update add \
         rsync tar bash shadow ca-certificates \
         supervisor \
-        perl perl-archive-zip perl-xml-rss perl-cgi perl-file-listing perl-json-xs \
+        perl perl-archive-zip perl-xml-rss perl-cgi perl-file-listing perl-json-xs perl-time-parsedate \
         expat samba-client iputils openssh openssl rrdtool ttf-dejavu \
         msmtp lighttpd lighttpd-mod_auth apache2-utils tzdata libstdc++ libgomp \
         gzip pigz \

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -17,7 +17,7 @@ if [ -f /firstrun ]; then
 
 	# Configure timezone if needed
 	if [ -n "$TZ" ]; then
-		cp /usr/share/zoneinfo/$TZ /etc/localtime 
+		cp /usr/share/zoneinfo/$TZ /etc/localtime
 	fi
 
 	# Create backuppc user/group if needed
@@ -108,6 +108,8 @@ if [ -f /firstrun ]; then
 	touch /var/log/lighttpd/error.log && chown -R "$BACKUPPC_USERNAME":"$BACKUPPC_GROUPNAME" /var/log/lighttpd
 
 	# Configure standard mail delivery parameters (may be overriden by backuppc user-wide config)
+	touch /var/log/msmtp.log
+	chown "${BACKUPPC_USERNAME}:${BACKUPPC_GROUPNAME}" /var/log/msmtp.log
 	if [ ! -f /etc/msmtprc ]; then
 		echo "account default" > /etc/msmtprc
 		echo "logfile /var/log/msmtp.log" >> /etc/msmtprc
@@ -115,8 +117,6 @@ if [ -f /firstrun ]; then
 		if [ "${SMTP_MAIL_DOMAIN:-}" != "" ]; then
 			echo "from %U@${SMTP_MAIL_DOMAIN}" >> /etc/msmtprc
 		fi
-		touch /var/log/msmtp.log
-		chown "${BACKUPPC_USERNAME}:${BACKUPPC_GROUPNAME}" /var/log/msmtp.log
 	fi
 
 	# Clean


### PR DESCRIPTION
Allows use of `BackupPC_fixupBackupSummary`, which requires perl `Time:ParseDate` module.