### PR TITLE
add option to use starttls for ldap connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ You can also authorize against an Active Directory / LDAP. The following Paramet
 | `LDAP_BIND_PW` | LDAP Password | SuperSecretPassword |
 | `LDAP_BACKUPPC_ADMIN` | LDAP user with with backuppc admin rights | backuppcadmin |
 
+#### STARTTLS with LDAP
+
+You can also use STARTTLS for the LDAP connection. In order to do so, set the optional parameter `LDAP_STARTTLS=1` and mount the CA file, which is used by the server, as a volume into the container.
+
+```bash
+docker run \
+    --name backuppc \
+    --publish 80:8080 \
+    --volume /path/to/cafile/ca.pem:/etc/ldap/ca.pem:ro \
+    --env 'LDAP_STARTTLS=1' \
+    --env […other LDAP parameter…] \
+    adferrand/backuppc 
+```
+
 ### Advanced configuration
 
 One may need more advanced authentication/authorization on Backuppc Web UI, for instance several *normal* users allowing operations on backups, and an *admin* user to parameterize BackupPC.

--- a/files/auth-ldap.conf
+++ b/files/auth-ldap.conf
@@ -2,6 +2,8 @@ server.modules                          += ( "mod_authn_ldap" )
 
 auth.backend                            = "ldap"
 auth.backend.ldap.hostname              = "LDAP_HOSTNAME"
+auth.backend.ldap.starttls              = "LDAP_STARTTLS"
+auth.backend.ldap.ca-file               = "/etc/ldap/ca.pem"
 auth.backend.ldap.base-dn               = "LDAP_BASE_DN"
 auth.backend.ldap.filter                = "LDAP_FILTER"
 auth.backend.ldap.allow-empty-pw        = "disable"

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -97,6 +97,13 @@ if [ -f /firstrun ]; then
 	if [ "$AUTH_METHOD" == "ldap" ]; then
 
 		sed -i 's#LDAP_HOSTNAME#'"$LDAP_HOSTNAME"'#g' /etc/lighttpd/auth-ldap.conf
+
+		if [ "$LDAP_STARTTLS" == "1" ]; then
+			sed -i 's#LDAP_STARTTLS#1#g' /etc/lighttpd/auth-ldap.conf
+		else
+			sed -i 's#LDAP_STARTTLS#0#g' /etc/lighttpd/auth-ldap.conf
+		fi
+
 		sed -i 's#LDAP_BASE_DN#'"$LDAP_BASE_DN"'#g' /etc/lighttpd/auth-ldap.conf
 		LDAP_FILTER=$(sed 's#&#\\&#g' <<< "$LDAP_FILTER")
 		sed -i 's#LDAP_FILTER#'"$LDAP_FILTER"'#g' /etc/lighttpd/auth-ldap.conf


### PR DESCRIPTION
This will add an option to use STARTTLS for LDAP connections to prevent passwords send in plaintext over the network.